### PR TITLE
Add EntityBase and implement domain entities

### DIFF
--- a/Core/OnionArc.Domain/Common/EntityBase.cs
+++ b/Core/OnionArc.Domain/Common/EntityBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Common;
+
+public class EntityBase : IEntityBase
+{
+    public int Id { get; set; }
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedDate { get; set; } = DateTime.UtcNow;
+    public bool IsDeleted { get; set; } = false;
+}

--- a/Core/OnionArc.Domain/Common/IEntityBase.cs
+++ b/Core/OnionArc.Domain/Common/IEntityBase.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Common;
+
+public interface IEntityBase
+{
+}

--- a/Core/OnionArc.Domain/Entities/Brand.cs
+++ b/Core/OnionArc.Domain/Entities/Brand.cs
@@ -1,0 +1,23 @@
+﻿using OnionArc.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Entities;
+
+public class Brand : EntityBase
+{
+    public Brand()
+    {
+
+    }
+    public Brand(string name, string logo)
+    {
+        Name = name;
+        Logo = logo;
+    }
+    public required string Name { get; set; }
+    public required string Logo { get; set; }
+}

--- a/Core/OnionArc.Domain/Entities/Category.cs
+++ b/Core/OnionArc.Domain/Entities/Category.cs
@@ -1,0 +1,30 @@
+﻿using OnionArc.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Entities;
+
+public class Category : EntityBase
+{
+    public Category()
+    {
+        
+    }
+
+    public Category(int parentId, string name, int priorty)
+    {
+        ParentId = parentId;
+        Name = name;
+        Priorty = priorty;
+    }
+
+    public required int ParentId { get; set; }
+    public required string Name { get; set; }
+    public required int Priorty { get; set; }
+
+    public ICollection<Detail> Details { get; set; }
+    public ICollection<Product> Products { get; set; }
+}

--- a/Core/OnionArc.Domain/Entities/Detail.cs
+++ b/Core/OnionArc.Domain/Entities/Detail.cs
@@ -1,0 +1,28 @@
+﻿using OnionArc.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Entities;
+
+public class Detail : EntityBase
+{
+    public Detail()
+    {
+
+    }
+
+    public Detail(string title, string description, int categoryId)
+    {
+        Title = title;
+        Description = description;
+        CategoryId = categoryId;
+    }
+
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+    public required int CategoryId { get; set; }
+    public Category Category { get; set; }
+}

--- a/Core/OnionArc.Domain/Entities/Product.cs
+++ b/Core/OnionArc.Domain/Entities/Product.cs
@@ -1,0 +1,21 @@
+﻿using OnionArc.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnionArc.Domain.Entities;
+
+public class Product : EntityBase
+{
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+    public required int BrandId { get; set; }
+    public required decimal Price { get; set; }
+    public required decimal Discount { get; set; }
+    //public required string ImageUrl { get; set; }
+
+    public Brand Brand { get; set; }
+    public ICollection<Category> Categories { get; set; }
+}


### PR DESCRIPTION
Add EntityBase and implement domain entities

Introduce a base class `EntityBase` with common properties
for all entities, and define the `IEntityBase` interface.
Create `Brand`, `Category`, `Detail`, and `Product` classes
that inherit from `EntityBase`, each with specific properties
and relationships, enhancing the structure and organization
of the domain model.